### PR TITLE
ssh鍵周りの仕様変更(再)

### DIFF
--- a/manifests/manager/app.pp
+++ b/manifests/manager/app.pp
@@ -1,12 +1,13 @@
 define mha::manager::app (
-  $nodes         = [],
-  $user          = $mha::params::user,
-  $password      = $mha::params::password,
-  $repl_user     = $mha::params::repl_user,
-  $repl_password = $mha::params::repl_password,
-  $ssh           = $mha::params::ssh,
-  $default       = {},
-  $manage_daemon = false
+  $nodes           = [],
+  $user            = $mha::params::user,
+  $password        = $mha::params::password,
+  $repl_user       = $mha::params::repl_user,
+  $repl_password   = $mha::params::repl_password,
+  $ssh_key_path    = $mha::params::ssh_key_path,
+  $ssh_private_key = $mha::params::ssh_private_key,
+  $default         = {},
+  $manage_daemon   = false
 ) {
 
   include mha::params
@@ -25,7 +26,10 @@ define mha::manager::app (
     group   => 'root',
   }
 
-  create_resources(mha::ssh_keys, { "mha::app::${name}" => $ssh })
+  mha::ssh_private_key { "mha::manager::$name":
+    path    => $ssh_key_path,
+    content => $ssh_private_key,
+  }
 
   if $manage_daemon {
     include supervisor

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -1,12 +1,15 @@
 class mha::node (
   $manager,
-  $version       = $mha::params::node_version,
-  $nodes         = [],
-  $user          = $mha::params::user,
-  $password      = $mha::params::password,
-  $repl_user     = $mha::params::repl_user,
-  $repl_password = $mha::params::repl_password,
-  $ssh           = $mha::params::ssh,
+  $version         = $mha::params::node_version,
+  $nodes           = [],
+  $user            = $mha::params::user,
+  $password        = $mha::params::password,
+  $repl_user       = $mha::params::repl_user,
+  $repl_password   = $mha::params::repl_password,
+  $ssh_key_path    = $mha::params::ssh_key_path,
+  $ssh_key_type    = $mha::params::ssh_key_type,
+  $ssh_public_key  = $mha::params::ssh_public_key,
+  $ssh_private_key = $mha::params::ssh_private_key,
   $purge_relay_logs_schedule = $mha::params::purge_relay_logs_schedule,
 ) inherits mha::params {
 
@@ -18,7 +21,17 @@ class mha::node (
     $service_name = 'mysql'
   }
 
-  create_resources('mha::ssh_keys', { "mha::node" => $ssh })
+  mha::ssh_private_key { 'mha::node':
+    path    => $ssh_key_path,
+    content => $ssh_private_key,
+  }
+
+  ensure_resource('ssh_authorized_key', 'mha::node', {
+    ensure => present,
+    user   => 'root',
+    type   => $ssh_key_type,
+    key    => $ssh_public_key,
+  })
 
      Service[$service_name]
   -> class { 'mha::node::install': version => $version }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -9,17 +9,42 @@ class mha::params {
   $repl_user     = 'repl'
   $repl_password = ''
 
-  $ssh = {
-    user        => root,
-    key_path    => '/root/.ssh/id_rsa_mha',
-    private_key => 'puppet:///modules/mha/id_rsa',
-    public_key  => 'AAAAB3NzaC1yc2EAAAABIwAAAQEArtdvtkbHIW0GOUcDSBJtK0ql14YMLGxyvROqWUzH89UhMzUoMyViFMYdKDJJ/99F/vTiMtTl4lAyw93UVTMAyI1wfDlUjv9CDEWshuFUW6FPRSYJq+zo9GXrLZK84UJItjngP5Zdxuyd38chSPfnBG5scrlsgwVZmQEU9wStWhYewU/DKvXmMvX7b2nzmvaaTKdl6tAOq5ZFC51DVaYk1dpNW8LpjL617Gfj69z5ot+zexXZgIIJapjmpyaqSeGg834W9YaUFtCGXnKIrOQuseiRz4TE0wLJ5V+4VqQM6CDrN90QX23WTXLLkkvMXYg97rbPriO8+T5y7t9ugYx/Qw==',
-  }
-
   $purge_relay_logs_schedule = {
     minute => 10,
     hour   => '2-23/6', # 2,8,14,20
   }
+
+  $ssh_key_path    = '/root/.ssh/id_mha'
+  $ssh_key_type    = 'rsa'
+  $ssh_public_key  = 'AAAAB3NzaC1yc2EAAAABIwAAAQEArtdvtkbHIW0GOUcDSBJtK0ql14YMLGxyvROqWUzH89UhMzUoMyViFMYdKDJJ/99F/vTiMtTl4lAyw93UVTMAyI1wfDlUjv9CDEWshuFUW6FPRSYJq+zo9GXrLZK84UJItjngP5Zdxuyd38chSPfnBG5scrlsgwVZmQEU9wStWhYewU/DKvXmMvX7b2nzmvaaTKdl6tAOq5ZFC51DVaYk1dpNW8LpjL617Gfj69z5ot+zexXZgIIJapjmpyaqSeGg834W9YaUFtCGXnKIrOQuseiRz4TE0wLJ5V+4VqQM6CDrN90QX23WTXLLkkvMXYg97rbPriO8+T5y7t9ugYx/Qw=='
+  $ssh_private_key = '-----BEGIN RSA PRIVATE KEY-----
+MIIEowIBAAKCAQEArtdvtkbHIW0GOUcDSBJtK0ql14YMLGxyvROqWUzH89UhMzUo
+MyViFMYdKDJJ/99F/vTiMtTl4lAyw93UVTMAyI1wfDlUjv9CDEWshuFUW6FPRSYJ
+q+zo9GXrLZK84UJItjngP5Zdxuyd38chSPfnBG5scrlsgwVZmQEU9wStWhYewU/D
+KvXmMvX7b2nzmvaaTKdl6tAOq5ZFC51DVaYk1dpNW8LpjL617Gfj69z5ot+zexXZ
+gIIJapjmpyaqSeGg834W9YaUFtCGXnKIrOQuseiRz4TE0wLJ5V+4VqQM6CDrN90Q
+X23WTXLLkkvMXYg97rbPriO8+T5y7t9ugYx/QwIBIwKCAQEAn9rpyzllmudWJb1E
+1C4aqzzvZfbmjwQRIeYYFyGg3u6/RMLi7O76lqaBDs7kkis4rpbALnmBuPjd9OgS
+lwoPWEbNPmBNT4pLA+fuMi0Z7WBIebxgnTBf9WR/P5waZ40PR4VfUBRy/wQ4khUl
+vw6KEq4aAn2lChOFHizf98nDEIe91GJF0FgSclAJGi8AhayaAe3bmB1SDRTYA2mZ
+LrhJq8UTectSGlo8NKcf3ivPoDVdebCfpOx6+vIVOAaQ991jZZjbTrNgV26jpODY
+YqkY7YS2Zy0a0eWGLof7b+Q2mvFzf0cTXT8vZWfRpfEgWexjvU6NJUM2Tzonpj2E
+VMQriwKBgQDT34T5DO4AgQdfcEokErh2phuI1E1bp835VZkzF5olTEc6pv9ZhzLp
+Y2ImC0/i+to69d8bIyBjTdishP0t+mpbFtv36ZzjGbiFOkWg4TOz5q/C+/GEyQXg
+rNRXuY3A/z2cfy2hU/lo53bdrXlo0TYEJbmzdHRqAlgLlMy0PpvjUQKBgQDTQX9N
+wieRhOcSCnxm9glbNG+06CKhRXl/ckiQsvJu9bOFZ40uOLkar27zBY0rkMsaSB2P
+wP7/mkdy7OJNwF0hJYLvLdV/nXb+J9b7H8eHh2+nUrnqtGnedaalmrSwL2s4ZXmx
+3XdRjxJgl1KoKfesse8x2O3PkD7L/D9xhjoMUwKBgQDN0dGhekZJoennrujv16vg
++SIP5C3kAhiLz37hLN7iZ1sjCKBIV3NJHrcdpJa/PNP+wvX9Gs8BYZCnlyHU5KHU
+1GCnr7z53ni773bWzCOY0XeKNpLYw0eJzHaBGqb1/0MqT6irWOOnvEeVg/JIkLgh
+STgNadAsd043ItV75Qx2awKBgQDBJfC8HzoepWWM1mMcTql39W1yM1Lcl0qDJqi+
+z36RVatyp9GJWG65T/BpKaWkLJxvzOfT46dQGAbPeX5y+QSwl1Mj0iJIyntsByr0
+OlAG4joylMc8/LiQ4Jhc5Td8gyAzj/o8ODKTtgIsbRhfPFAo3TJ2t7TbB4nfEoMl
+9xCASwKBgHU8zO3C1xPQjh8hso1+ypIoJNu1IX/xN784BpxfGH0xAHIFJqAavQ2b
+kg5/f5OY4sfCDqVqB381m0yx1bRHiPrT6gwQFUpFjCiMO9kF2e7c2X072iA6rQAN
+vsTLvLSpURCF6XLRL/u0WxavQk9pr5hvJVahu6xGpToe3/8uH+vH
+-----END RSA PRIVATE KEY-----
+'
 
 }
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "lamanotrama-mha",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "author": "lamanotrama",
   "summary": "MHA Module",
   "license": "Apache 2.0",

--- a/templates/etc/masterha/app.cnf
+++ b/templates/etc/masterha/app.cnf
@@ -1,6 +1,6 @@
 [server default]
-ssh_user=<%= @ssh['user'] %>
-ssh_options='-i <%= @ssh['key_path'] %>'
+ssh_user=root
+ssh_options='-i <%= @ssh_key_path %>'
 
 user=<%= @user %>
 password=<%= @password %>


### PR DESCRIPTION
- userはrootに固定
  - 普通はrootを使うし、root以外を考慮すると色々面倒
- typeも指定可能に
- pathと、秘密/後悔鍵、typeを個別のパラメータに変更
  - pathだけデフォルトを使うとかしたい
- manager側には公開鍵を登録しない
  - node側から接続する必要はない。出来ない方がいい。
- 秘密鍵はcontentで管理
  - hiera等で管理する場合、content渡しの方が取り回しがしやすい
- 公開鍵の名前変更
