### PR TITLE
Fix for Puppet 4

### DIFF
--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -27,10 +27,10 @@ class mha::node (
   }
 
   ensure_resource('ssh_authorized_key', 'mha::node', {
-    ensure => present,
-    user   => 'root',
-    type   => $ssh_key_type,
-    key    => $ssh_public_key,
+    'ensure' => 'present',
+    'user'   => 'root',
+    'type'   => $ssh_key_type,
+    'key'    => $ssh_public_key,
   })
 
      Service[$service_name]

--- a/manifests/node/grants.pp
+++ b/manifests/node/grants.pp
@@ -30,13 +30,15 @@ define mha::node::grants::admin (
   $password,
 ) {
   ensure_resource('mysql_user',
-    "${user}@${host}" => {
+    "${user}@${host}",
+    {
       password_hash => mysql_password($password),
     }
   )
 
   ensure_resource('mysql_grant',
-    "${user}@${host}/*.*" => {
+    "${user}@${host}/*.*",
+    {
       user       => "${user}@${host}",
       table      => '*.*',
       privileges => ['ALL'],
@@ -50,13 +52,15 @@ define mha::node::grants::repl (
   $password,
 ) {
   ensure_resource('mysql_user',
-    "${user}@${host}" => {
+    "${user}@${host}",
+    {
       password_hash => mysql_password($password),
     }
   )
 
   ensure_resource('mysql_grant',
-    "${user}@${host}/*.*" => {
+    "${user}@${host}/*.*",
+    {
       user       => "${user}@${host}",
       table      => '*.*',
       privileges => [


### PR DESCRIPTION
Puppet 4 has changed some syntax and become parse strictly.
I fixed error using `puppet parser validate`.
