### PR TITLE
Newer MHA versions (from 0.56) will be hosted on Google Drive instead.

### DIFF
--- a/manifests/manager/install.pp
+++ b/manifests/manager/install.pp
@@ -4,7 +4,7 @@ class mha::manager::install {
 
   $ensure        = "${mha::manager::version}.el${::operatingsystemmajrelease}"
   $rpm           = "mha4mysql-manager-${ensure}.noarch.rpm"
-  $source_url    = "http://www.mysql.gr.jp/frame/modules/bwiki/index.php?plugin=attach&pcmd=open&file=${rpm}&refer=matsunobu"
+  $source_url    = "https://72003f4c60f5cc941cd1c7d448fc3c99e0aebaa8.googledrive.com/host/0B1lu97m8-haWeHdGWXp0YVVUSlk/${rpm}"
   $download_path = "/usr/local/src/${rpm}"
 
   if !defined(Class['mha::node::install']) {

--- a/manifests/node/install.pp
+++ b/manifests/node/install.pp
@@ -4,7 +4,7 @@ class mha::node::install (
 
   $ensure        = "${version}.el${::operatingsystemmajrelease}"
   $rpm           = "mha4mysql-node-${ensure}.noarch.rpm"
-  $source_url    = "http://www.mysql.gr.jp/frame/modules/bwiki/index.php?plugin=attach&pcmd=open&file=${rpm}&refer=matsunobu"
+  $source_url    = "https://72003f4c60f5cc941cd1c7d448fc3c99e0aebaa8.googledrive.com/host/0B1lu97m8-haWeHdGWXp0YVVUSlk/${rpm}"
   $download_path = "/usr/local/src/${rpm}"
 
   ensure_packages(['perl-DBD-MySQL', 'wget'])

--- a/manifests/node/install.pp
+++ b/manifests/node/install.pp
@@ -7,13 +7,13 @@ class mha::node::install (
   $source_url    = "https://72003f4c60f5cc941cd1c7d448fc3c99e0aebaa8.googledrive.com/host/0B1lu97m8-haWeHdGWXp0YVVUSlk/${rpm}"
   $download_path = "/usr/local/src/${rpm}"
 
-  ensure_packages(['perl-DBD-MySQL', 'wget'])
+  ensure_packages('perl-DBD-MySQL')
 
   # Because the rpm command on centos5 is failed.
   exec { 'download mha-node':
-    command => "/usr/bin/wget -O ${download_path} \"${source_url}\"",
+    command => "curl -L -o ${download_path} \"${source_url}\"",
+    path    => ['/bin', '/usr/bin', '/usr/local/bin'],
     creates => $download_path,
-    require => Package['wget'],
   }
 
   package { 'mha4mysql-node':

--- a/spec/acceptance/nodesets/centos5.yml
+++ b/spec/acceptance/nodesets/centos5.yml
@@ -9,4 +9,4 @@ HOSTS:
 CONFIG:
   type: foss
   masterless: true
-  # log_level: verbose
+  log_level: debug

--- a/spec/acceptance/nodesets/centos6.yml
+++ b/spec/acceptance/nodesets/centos6.yml
@@ -9,4 +9,4 @@ HOSTS:
 CONFIG:
   type: foss
   masterless: true
-  # log_level: verbose
+  log_level: debug

--- a/spec/acceptance/nodesets/centos7.yml
+++ b/spec/acceptance/nodesets/centos7.yml
@@ -9,4 +9,4 @@ HOSTS:
 CONFIG:
   type: foss
   masterless: true
-  # log_level: debug
+  log_level: debug


### PR DESCRIPTION
ref: https://72003f4c60f5cc941cd1c7d448fc3c99e0aebaa8.googledrive.com/host/0B1lu97m8-haWeHdGWXp0YVVUSlk/
