### PR TITLE
Stop using ensure_resource()

### DIFF
--- a/manifests/manager/app.pp
+++ b/manifests/manager/app.pp
@@ -12,18 +12,19 @@ define mha::manager::app (
 
   include mha::params
 
-  $config = "/etc/masterha/${name}.cnf"
-
-  ensure_resource('file', '/etc/masterha', {
+  file {
+    '/etc/masterha':
     ensure => directory,
-    mode   => 755,
-  })
+    owner  => 'root',
+    group  => 'root',
+    mode   => '0755';
 
-  file { $config:
+  "/etc/masterha/${name}.cnf":
+    ensure  => present,
     content => template('mha/etc/masterha/app.cnf'),
     mode    => '0600',
     owner   => 'root',
-    group   => 'root',
+    group   => 'root';
   }
 
   mha::ssh_private_key { "mha::manager::${name}":
@@ -37,7 +38,7 @@ define mha::manager::app (
     supervisor::program { "masterha_manager_${name}":
       ensure                 => present,
       enable                 => true,
-      command                => "/usr/bin/masterha_manager --conf=${config}",
+      command                => "/usr/bin/masterha_manager --conf=/etc/masterha/${name}.cnf",
       startsecs              => 10,
       autorestart            => true,
       user                   => 'root',
@@ -51,4 +52,3 @@ define mha::manager::app (
   }
 
 }
-

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -21,17 +21,18 @@ class mha::node (
     $service_name = 'mysql'
   }
 
+  ssh_authorized_key { 'mha::node':
+    ensure => present,
+    user   => 'root',
+    type   => $ssh_key_type,
+    key    => $ssh_public_key,
+  }
+
   mha::ssh_private_key { 'mha::node':
     path    => $ssh_key_path,
     content => $ssh_private_key,
+    require => Ssh_authorized_key['mha::node'],
   }
-
-  ensure_resource('ssh_authorized_key', 'mha::node', {
-    'ensure' => 'present',
-    'user'   => 'root',
-    'type'   => $ssh_key_type,
-    'key'    => $ssh_public_key,
-  })
 
   Service[$service_name]
   -> class { 'mha::node::install': version => $version }

--- a/manifests/node/grants/admin.pp
+++ b/manifests/node/grants/admin.pp
@@ -3,19 +3,15 @@ define mha::node::grants::admin (
   $password,
   $host = $name,
 ) {
-  ensure_resource('mysql_user',
-    "${user}@${host}",
-    {
-      password_hash => mysql_password($password),
-    }
-  )
 
-  ensure_resource('mysql_grant',
-    "${user}@${host}/*.*",
-    {
-      user       => "${user}@${host}",
-      table      => '*.*',
-      privileges => ['ALL'],
-    }
-  )
+  mysql_user { "${user}@${host}":
+    password_hash => mysql_password($password),
+  }
+
+  mysql_grant { "${user}@${host}/*.*":
+    user       => "${user}@${host}",
+    table      => '*.*',
+    privileges => ['ALL'],
+  }
+
 }

--- a/manifests/node/grants/repl.pp
+++ b/manifests/node/grants/repl.pp
@@ -3,22 +3,18 @@ define mha::node::grants::repl (
   $password,
   $host = $name,
 ) {
-  ensure_resource('mysql_user',
-    "${user}@${host}",
-    {
-      password_hash => mysql_password($password),
-    }
-  )
 
-  ensure_resource('mysql_grant',
-    "${user}@${host}/*.*",
-    {
-      user       => "${user}@${host}",
-      table      => '*.*',
-      privileges => [
-        'REPLICATION SLAVE',
-        'REPLICATION CLIENT',
-      ],
-    }
-  )
+  mysql_user { "${user}@${host}":
+    password_hash => mysql_password($password),
+  }
+
+  mysql_grant {"${user}@${host}/*.*":
+    user       => "${user}@${host}",
+    table      => '*.*',
+    privileges => [
+      'REPLICATION SLAVE',
+      'REPLICATION CLIENT',
+    ],
+  }
+
 }

--- a/manifests/ssh_private_key.pp
+++ b/manifests/ssh_private_key.pp
@@ -3,21 +3,11 @@ define mha::ssh_private_key (
   $content,
 ) {
 
-  if $path =~ /^\/root\/.ssh\// {
-    ensure_resource('file', '/root/.ssh', {
-      ensure => directory,
-      owner  => 'root',
-      group  => 'root',
-      mode   => '0700',
-      before => File[$path],
-    })
-  }
-
-  ensure_resource('file', $path, {
+  file { $path:
     owner   => 'root',
     group   => 'root',
     mode    => '0600',
     content => $content,
-  })
+  }
 
 }

--- a/spec/defines/ssh_private_key_spec.rb
+++ b/spec/defines/ssh_private_key_spec.rb
@@ -14,7 +14,6 @@ describe 'mha::ssh_private_key' do
     it { should compile }
     it { should compile.with_all_deps }
 
-    it { should contain_file('/root/.ssh').with_ensure('directory') }
     it { should contain_file('/root/.ssh/id_mha') }
   end
 end


### PR DESCRIPTION
ensure_resource() is useful, but, basically, it's better to avoid duplicating resource declarations, and Puppet modules should emit conflict errors.
