### PR TITLE
Specify any ssh user

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ Install and configure mha4mysql-node, create grant permissions to access MySQL f
 - `password`: The MySQL password of the "$user" user ([ref](https://code.google.com/p/mysql-master-ha/wiki/Parameters#password)). Default to '' (empty).
 - `repl_user`: The MySQL replication username ([ref](https://code.google.com/p/mysql-master-ha/wiki/Parameters#repl_user)). Default to 'repl'.
 - `repl_password`: The MySQL password of the repl user ([ref](https://code.google.com/p/mysql-master-ha/wiki/Parameters#repl_password)). Default: '' (empty).
+- `ssh_user`: The user connecting to mha-node with ssh. Default to 'root'
 - `ssh_key_type`: The encryption type used ([ref](https://docs.puppet.com/puppet/latest/reference/types/ssh_authorized_key.html#ssh_authorized_key-attribute-type)).
 - `ssh_public_key`: The public key itself as the same as [Ssh_authorized_key key attributes](https://docs.puppet.com/puppet/latest/reference/types/ssh_authorized_key.html#ssh_authorized_key-attribute-key).
 - `ssh_key_path`: The path to the private key to manage. Default to '/root/.ssh/id\_mha'.

--- a/manifests/manager.pp
+++ b/manifests/manager.pp
@@ -2,6 +2,7 @@ class mha::manager (
   $version       = $mha::params::manager_version,
   $node_version  = $mha::params::node_version,
   $script_ensure = $mha::params::script_ensure,
+  $ssh_user      = $mha::params::ssh_user,
 ) inherits mha::params {
 
   validate_re($version, '^\d+\.\d+-\d+$', "${version} is not supported for version. This parameter should be like '0.57-0'.")

--- a/manifests/manager/app.pp
+++ b/manifests/manager/app.pp
@@ -29,8 +29,9 @@ define mha::manager::app (
   }
 
   mha::ssh_private_key { "mha::manager::${name}":
-    path    => $ssh_key_path,
-    content => $ssh_private_key,
+    ssh_user => $ssh_user,
+    path     => $ssh_key_path,
+    content  => $ssh_private_key,
   }
 
   if $manage_daemon {

--- a/manifests/manager/install.pp
+++ b/manifests/manager/install.pp
@@ -1,14 +1,19 @@
-class mha::manager::install {
+class mha::manager::install (
+  $version      = $mha::manager::version,
+  $node_version = $mha::manager::node_version,
+  $ssh_user     = $mha::manager::ssh_user,
+) {
 
   require ::epel
 
-  $ensure   = "${mha::manager::version}.el${::operatingsystemmajrelease}"
+  $ensure   = "${version}.el${::operatingsystemmajrelease}"
   $rpm      = "mha4mysql-manager-${ensure}.noarch.rpm"
   $rpm_path = "/usr/local/src/${rpm}"
 
   if !defined(Class['mha::node::install']) {
     class { 'mha::node::install':
-      version => $mha::manager::node_version,
+      version  => $node_version,
+      ssh_user => $ssh_user,
     }
   }
 

--- a/manifests/node.pp
+++ b/manifests/node.pp
@@ -6,6 +6,7 @@ class mha::node (
   $password        = $mha::params::password,
   $repl_user       = $mha::params::repl_user,
   $repl_password   = $mha::params::repl_password,
+  $ssh_user        = $mha::params::ssh_user,
   $ssh_key_type    = $mha::params::ssh_key_type,
   $ssh_public_key  = $mha::params::ssh_public_key,
   $ssh_key_path    = $mha::params::ssh_key_path,
@@ -18,12 +19,13 @@ class mha::node (
 
   ssh_authorized_key { 'mha::node':
     ensure => present,
-    user   => 'root',
+    user   => $ssh_user,
     type   => $ssh_key_type,
     key    => $ssh_public_key,
   }
 
   mha::ssh_private_key { 'mha::node':
+    user    => $ssh_user,
     path    => $ssh_key_path,
     content => $ssh_private_key,
     require => Ssh_authorized_key['mha::node'],

--- a/manifests/node/install.pp
+++ b/manifests/node/install.pp
@@ -1,5 +1,6 @@
 class mha::node::install (
-  $version = $mha::node::version,
+  $version  = $mha::node::version,
+  $ssh_user = $mha::node::ssh_user,
 ) {
 
   $ensure   = "${version}.el${::operatingsystemmajrelease}"
@@ -23,8 +24,7 @@ class mha::node::install (
 
   file { '/var/log/masterha':
     ensure => directory,
-    owner  => 'root',
-    group  => 'root',
+    owner  => $ssh_user,
     mode   => '0755',
   }
 

--- a/manifests/ssh_private_key.pp
+++ b/manifests/ssh_private_key.pp
@@ -1,13 +1,14 @@
 define mha::ssh_private_key (
+  $user,
   $path,
   $content,
 ) {
 
+  validate_string($user)
   validate_absolute_path($path)
 
   file { $path:
-    owner   => 'root',
-    group   => 'root',
+    owner   => $user,
     mode    => '0600',
     content => $content,
   }

--- a/spec/defines/ssh_private_key_spec.rb
+++ b/spec/defines/ssh_private_key_spec.rb
@@ -5,6 +5,7 @@ describe 'mha::ssh_private_key' do
 
   let(:params) do
     {
+      user: 'root',
       path: '/root/.ssh/id_mha',
       content: '',
     }


### PR DESCRIPTION
Currently the ssh user to use with MHA is root only.
In my production I would like to use non-root users in security policy.

This pull request be able to specify the ssh user of MHA.
