### PR TITLE
fixed bug variable name

### DIFF
--- a/manifests/manager/app.pp
+++ b/manifests/manager/app.pp
@@ -29,9 +29,9 @@ define mha::manager::app (
   }
 
   mha::ssh_private_key { "mha::manager::${name}":
-    ssh_user => $ssh_user,
-    path     => $ssh_key_path,
-    content  => $ssh_private_key,
+    user    => $ssh_user,
+    path    => $ssh_key_path,
+    content => $ssh_private_key,
   }
 
   if $manage_daemon {


### PR DESCRIPTION
https://github.com/hfm/puppet-mha/pull/25 has bug.
Output this error from my production.

```
Error: Invalid parameter ssh_user at modules/mha/manifests/manager/app.pp:35
```

Not same variable name. `ssh_user`

```
# manifests/manager/app.pp

mha::ssh_private_key { "mha::manager::${name}":
  ssh_user => $ssh_user,
  path     => $ssh_key_path,
  content  => $ssh_private_key,
}
```

```
# manifests/ssh_private_key.pp

define mha::ssh_private_key (
  $user,
  $path,
  $content,
) {
```

This PR is fixed this bug.
I'm sorry would put a bug.